### PR TITLE
Lora example

### DIFF
--- a/program-data-separation/README.md
+++ b/program-data-separation/README.md
@@ -27,5 +27,7 @@ To enable LoRA, we generate:
 
 Multiple LoRA-adapted PTE files can share the same foundation weights and adding a model adapted to a new task incurs minimal binary size and runtime memory overhead.
 
+Please take a look at [program-data-separation/cpp/lora_example](lora_example/) for a demo of the program-data separation APIs with LoRA. This example generates and runs a LoRA and a non-LoRA model that share foundation weights. At runtime, we see that memory usage does not double.
+
 ### Requirements
 LoRA is currently supported on executorch main. [Please install ExecuTorch pip package from source](https://docs.pytorch.org/executorch/stable/using-executorch-building-from-source.html#install-executorch-pip-package-from-source), until executorch==1.0 is released.

--- a/program-data-separation/cpp/CMakeLists.txt
+++ b/program-data-separation/cpp/CMakeLists.txt
@@ -41,8 +41,6 @@ if(EXECUTORCH_BUILD_LINEAR_DEMO)
 endif()
 if(EXECUTORCH_BUILD_LORA_DEMO)
   list(APPEND DEMO_SOURCES "lora_example/main.cpp")
-  add_subdirectory("executorch/examples/models/llama/runner")
-  list(APPEND LINK_LIBS llama_runner)
 endif()
 
 # Create executable

--- a/program-data-separation/cpp/CMakeLists.txt
+++ b/program-data-separation/cpp/CMakeLists.txt
@@ -14,29 +14,58 @@ option(EXECUTORCH_BUILD_EXTENSION_TENSOR "" ON)
 option(EXECUTORCH_BUILD_KERNELS_OPTIMIZED "" ON)
 option(EXECUTORCH_BUILD_XNNPACK "" ON)
 
-# Add ExecuTorch subdirectory
+# Dependencies required for llm runner in lora demo.
+if(EXECUTORCH_BUILD_LORA_DEMO)
+option(EXECUTORCH_BUILD_EXTENSION_LLM "" ON)
+option(EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER "" ON)
+option(EXECUTORCH_BUILD_KERNELS_LLM "" ON)
+option(EXECUTORCH_BUILD_KERNELS_LLM_AOT "" ON)
+endif()
+
+# Add ExecuTorch subdirectory, after setting options.
 add_subdirectory("executorch")
 
-set(DEMO_SOURCES linear_example/main.cpp)
+set(LINK_LIBS executorch
+              executorch::extensions
+              xnnpack_backend
+              # NOTE: xnnpack_backend has to go before
+              # kernels otherwise it doesn't get registered.
+              executorch::kernels
+              gflags
+)
+
+# Add sources and dependencies.
+set(DEMO_SOURCES "")
+if(EXECUTORCH_BUILD_LINEAR_DEMO)
+  list(APPEND DEMO_SOURCES "linear_example/main.cpp")
+endif()
+if(EXECUTORCH_BUILD_LORA_DEMO)
+  list(APPEND DEMO_SOURCES "lora_example/main.cpp")
+  add_subdirectory("executorch/examples/models/llama/runner")
+  list(APPEND LINK_LIBS llama_runner)
+endif()
 
 # Create executable
 add_executable(executorch_program_data_separation ${DEMO_SOURCES})
 
-# Include directories
-target_include_directories(executorch_program_data_separation PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-
 # Link libraries
 target_link_libraries(
   executorch_program_data_separation
-  PRIVATE executorch
-          extension_module_static
-          extension_flat_tensor
-          extension_tensor
-          xnnpack_backend
-          portable_ops_lib
-          portable_kernels
-          gflags
+  PRIVATE ${LINK_LIBS}
 )
+
+# Include directories for lora demo.
+if(EXECUTORCH_BUILD_LORA_DEMO)
+  # Include directories
+  target_include_directories(executorch_program_data_separation PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/executorch/extension/llm/tokenizers/include
+  )
+  target_link_libraries(
+    executorch_program_data_separation
+    PUBLIC tokenizers::tokenizers
+  )
+endif()
 
 # Set output directory
 set_target_properties(executorch_program_data_separation

--- a/program-data-separation/cpp/linear_example/build_example.sh
+++ b/program-data-separation/cpp/linear_example/build_example.sh
@@ -7,7 +7,7 @@ mkdir -p build
 cd build
 
 # Configure CMake
-cmake -DCMAKE_BUILD_TYPE=Release ../..
+cmake -DCMAKE_BUILD_TYPE=Release -DEXECUTORCH_BUILD_LINEAR_DEMO=True  ../..
 
 # Build the project
 cmake --build . -j$(nproc)

--- a/program-data-separation/cpp/lora_example/README.md
+++ b/program-data-separation/cpp/lora_example/README.md
@@ -76,7 +76,9 @@ sh build_example.sh
 ```
 
 ## Run the executable.
-```
+```bash
+cd ~/executorch-examples/program-data-separation/cpp/lora_example
+
 ./build/bin/executorch_program_data_separation --lora_model_path=../../llama_3_2_1B_lora.pte --llama_model_path=../../llama_3_2_1B.pte --tokenizer_path=../../tokenizer.model --data_path=../../foundation.ptd
 ```
 

--- a/program-data-separation/cpp/lora_example/README.md
+++ b/program-data-separation/cpp/lora_example/README.md
@@ -1,0 +1,73 @@
+# ExecuTorch Program Data Separation Demo C++.
+
+This directory contains the C++ code to run the examples generated in [program-data-separation](../program-data-separation/README.md).
+
+
+## Virtual environment setup.
+Create and activate a Python virtual environment:
+```bash
+python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
+```
+Or alternatively, [install conda on your machine](https://conda.io/projects/conda/en/latest/user-guide/install/index.html)
+```bash
+conda create -yn executorch-ptd python=3.10.0 && conda activate executorch-ptd
+```
+
+Install dependencies:
+```bash
+pip install executorch==0.7.0
+```
+
+## Export the model/s.
+
+Change into the program-data-separation directory and create a directory to hold exported artifacts.
+```bash
+cd ~/executorch-examples/program-data-separation
+mkdir models
+```
+
+Export models into the `models` directory. The first command will generated undelegated model/data files, and the second will generate XNNPACK-delegated model/data files.
+```bash
+./export_lora.sh
+```
+Expect the files `lora.pte` and `lora.ptd`.
+
+Note:
+- PTE: contains the program execution logic.
+- PTD: contains the constant tensors used by the PTE.
+
+See [program-data-separation](../../program-data-separation/README.md) for instructions.
+
+## Install runtime dependencies.
+The ExecuTorch repository is configured as a git submodule at `~/executorch-examples/program-data-separation/cpp/executorch`.  To initialize it:
+```bash
+cd ~/executorch-examples/
+git submodule sync
+git submodule update --init --recursive
+```
+Install dev requirements for ExecuTorch
+
+```bash
+cd ~/executorch-examples/program-data-separation/cpp/executorch
+pip install -r requirements-dev.txt
+```
+
+## Build the runtime.
+Build the executable:
+```bash
+cd ~/executorch-examples/program-data-separation/cpp/lora_example
+chmod +x build_example.sh
+./build_example.sh
+```
+
+## Run the executable.
+```
+./build/bin/executorch_program_data_separation --model-path ../../models/linear.pte --data-path ../../models/linear.ptd
+
+./build/bin/executorch_program_data_separation --model-path ../../models/linear_xnnpack.pte --data-path ../../models/linear_xnnpack.ptd
+```
+
+## Clean up.
+rm -rf build
+cd ~/executorch-examples/program-data-separation
+rm -rf models

--- a/program-data-separation/cpp/lora_example/README.md
+++ b/program-data-separation/cpp/lora_example/README.md
@@ -14,12 +14,16 @@ conda create -yn executorch-ptd python=3.10.0 && conda activate executorch-ptd
 ```
 
 Install dependencies:
-```bash
-pip install executorch==0.7.0
+LoRA isn't available in the 0.7.0 release of ExecuTorch. Instead, please install from source until ExecuTorch 1.0 is released.
+
+[Install ExecuTorch pip package from source](https://docs.pytorch.org/executorch/stable/using-executorch-building-from-source.html#install-executorch-pip-package-from-source).
+
+Currently, the LoRA changes aren't in nightlies. Once they are in, you can also install from the nightly build.
+```
+pip install executorch==0.8.0.devYYYYMMDD --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 ```
 
 ## Export the model/s.
-
 Change into the program-data-separation directory and create a directory to hold exported artifacts.
 ```bash
 cd ~/executorch-examples/program-data-separation
@@ -28,15 +32,21 @@ mkdir models
 
 Export models into the `models` directory. The first command will generated undelegated model/data files, and the second will generate XNNPACK-delegated model/data files.
 ```bash
-./export_lora.sh
+sh export_lora.sh
 ```
-Expect the files `lora.pte` and `lora.ptd`.
+Expect the files:
+- llama_3_2_1B.pte
+- llama_3_2_1B.ptd
+- llama_3_2_1B_lora.pte
+- foundation_weights.ptd
+- tokenizer.model
+
+llama_3_2_1B.ptd and foundation_weights.ptd contain the same contents, and you can remove llama_3_2_1B.ptd.
+tokenizer.model is copied from the temp directory where we downloaded the HF artifacts. It will be used at runtime.
 
 Note:
 - PTE: contains the program execution logic.
 - PTD: contains the constant tensors used by the PTE.
-
-See [program-data-separation](../../program-data-separation/README.md) for instructions.
 
 ## Install runtime dependencies.
 The ExecuTorch repository is configured as a git submodule at `~/executorch-examples/program-data-separation/cpp/executorch`.  To initialize it:
@@ -53,21 +63,24 @@ pip install -r requirements-dev.txt
 ```
 
 ## Build the runtime.
+Install some dependencies:
+```bash
+cd ~/executorch-examples/program-data-separation/cpp/executorch
+sh examples/models/llama/install_requirements.sh
+```
+
 Build the executable:
 ```bash
 cd ~/executorch-examples/program-data-separation/cpp/lora_example
-chmod +x build_example.sh
-./build_example.sh
+sh build_example.sh
 ```
 
 ## Run the executable.
 ```
-./build/bin/executorch_program_data_separation --model-path ../../models/linear.pte --data-path ../../models/linear.ptd
-
-./build/bin/executorch_program_data_separation --model-path ../../models/linear_xnnpack.pte --data-path ../../models/linear_xnnpack.ptd
+./build/bin/executorch_program_data_separation --lora_model_path=../../llama_3_2_1B_lora.pte --llama_model_path=../../llama_3_2_1B.pte --tokenizer_path=../../tokenizer.model --data_path=../../foundation.ptd
 ```
 
 ## Clean up.
 rm -rf build
 cd ~/executorch-examples/program-data-separation
-rm -rf models
+rm -rf *.pte *.ptd tokenizer.model

--- a/program-data-separation/cpp/lora_example/build_example.sh
+++ b/program-data-separation/cpp/lora_example/build_example.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Clean and create build directory if it doesn't exist
+rm -rf build
+mkdir -p build
+cd build
+
+# Configure CMake
+cmake -DCMAKE_BUILD_TYPE=Release -DEXECUTORCH_BUILD_LORA_DEMO=True ../..
+
+# Build the project
+cmake --build . -j$(nproc)
+
+echo "Build complete! Executable located at: ./build/bin/executorch_program_data_separation"

--- a/program-data-separation/cpp/lora_example/build_example.sh
+++ b/program-data-separation/cpp/lora_example/build_example.sh
@@ -7,7 +7,7 @@ mkdir -p build
 cd build
 
 # Configure CMake
-cmake -DCMAKE_BUILD_TYPE=Release -DEXECUTORCH_BUILD_LORA_DEMO=True ../..
+cmake -DCMAKE_BUILD_TYPE=Release -DEXECUTORCH_BUILD_LORA_DEMO=True -DEXECUTORCH_XNNPACK_ENABLE_WEIGHT_CACHE=True ../..
 
 # Build the project
 cmake --build . -j$(nproc)

--- a/program-data-separation/cpp/lora_example/main.cpp
+++ b/program-data-separation/cpp/lora_example/main.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ * @lint-ignore-every CLANGTIDY facebook-hte-Deprecated
+ */
+#include <gflags/gflags.h>
+
+#include <executorch/examples/models/llama/runner/runner.h>
+
+#if defined(ET_USE_THREADPOOL)
+#include <executorch/extension/threadpool/cpuinfo_utils.h>
+#include <executorch/extension/threadpool/threadpool.h>
+#endif
+
+DEFINE_string(lora_model_path, "llama_3_2_1B_lora.pte",
+              "LoRA model serialized in flatbuffer format.");
+DEFINE_string(llama_model_path, "llama_3_2_1B.pte",
+              "Model serialized in flatbuffer format.");
+DEFINE_string(data_path, "foundation.ptd",
+              "Data serialized in flatbuffer format.");
+
+DEFINE_string(tokenizer_path, "tokenizer.model", "Tokenizer stuff.");
+
+DEFINE_string(prompt, "The answer to the ultimate question is", "Prompt.");
+
+DEFINE_double(temperature, 0,
+              "Temperature; Default is 0. 0 = greedy argmax sampling "
+              "(deterministic). Lower temperature = more deterministic");
+
+DEFINE_int32(
+    seq_len, 128,
+    "Total number of tokens to generate (prompt + output). Defaults to "
+    "max_seq_len. If the number of input tokens + seq_len > max_seq_len, the "
+    "output will be truncated to max_seq_len tokens.");
+
+using namespace ::executorch::extension;
+
+int main(int argc, char *argv[]) {
+  ET_LOG(Info, "Running program-data separation lora example...");
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  const char *lora_model_path = FLAGS_lora_model_path.c_str();
+  const char *llama_model_path = FLAGS_llama_model_path.c_str();
+  const char *data_path = FLAGS_data_path.c_str();
+
+  const char *tokenizer_path = FLAGS_tokenizer_path.c_str();
+  const char *prompt = FLAGS_prompt.c_str();
+  float temperature = FLAGS_temperature;
+  int32_t seq_len = 128;
+  int32_t cpu_threads = -1;
+
+  // Create runner for lora model.
+  std::unique_ptr<::executorch::extension::llm::TextLLMRunner> lora_runner =
+      example::create_llama_runner(lora_model_path, tokenizer_path, data_path);
+  if (lora_runner == nullptr) {
+    ET_LOG(Error, "Failed to create lora_runner.");
+    return 1;
+  }
+
+  // create runner for llama model
+  std::unique_ptr<::executorch::extension::llm::TextLLMRunner> llama_runner =
+      example::create_llama_runner(llama_model_path, tokenizer_path, data_path);
+  if (llama_runner == nullptr) {
+    ET_LOG(Error, "Failed to create llama_runner.");
+    return 1;
+  }
+
+  // generate
+  executorch::extension::llm::GenerationConfig config{
+      .seq_len = seq_len, .temperature = temperature};
+
+  auto error = lora_runner->generate(prompt, config);
+  if (error != executorch::runtime::Error::Ok) {
+    ET_LOG(Error, "Failed to generate with lora_runner, error code %zu.",
+           error);
+    return 1;
+  }
+
+  ET_LOG(Info, "Generating with llama...");
+  error = llama_runner->generate(prompt, config);
+  if (error != executorch::runtime::Error::Ok) {
+    ET_LOG(Error, "Failed to generate with llama_runner, error code %zu.",
+           error);
+    return 1;
+  }
+
+  return 0;
+}

--- a/program-data-separation/cpp/lora_example/main.cpp
+++ b/program-data-separation/cpp/lora_example/main.cpp
@@ -28,8 +28,8 @@ DEFINE_string(lora_model_path, "llama_3_2_1B_lora.pte",
               "LoRA model serialized in flatbuffer format.");
 DEFINE_string(llama_model_path, "llama_3_2_1B.pte",
               "Model serialized in flatbuffer format.");
-DEFINE_string(data_path, "foundation.ptd",
-              "Data serialized in flatbuffer format.");
+DEFINE_string(foundation_weights_path, "foundation.ptd",
+              "Foundation weights serialized in flatbuffer format.");
 
 DEFINE_string(tokenizer_path, "tokenizer.model", "Tokenizer stuff.");
 
@@ -77,7 +77,7 @@ int main(int argc, char *argv[]) {
 
   const char *lora_model_path = FLAGS_lora_model_path.c_str();
   const char *llama_model_path = FLAGS_llama_model_path.c_str();
-  const char *data_path = FLAGS_data_path.c_str();
+  const char *foundation_weights_path = FLAGS_foundation_weights_path.c_str();
 
   const char *tokenizer_path = FLAGS_tokenizer_path.c_str();
   const char *prompt = FLAGS_prompt.c_str();
@@ -102,9 +102,10 @@ int main(int argc, char *argv[]) {
   // Create runners.
   std::unique_ptr<llm::TextLLMRunner> llama_runner =
       llm::create_text_llm_runner(llama_model_path, std::move(tokenizer1),
-                                  data_path, temperature);
-  std::unique_ptr<llm::TextLLMRunner> lora_runner = llm::create_text_llm_runner(
-      lora_model_path, std::move(tokenizer2), data_path, temperature);
+                                  foundation_weights_path, temperature);
+  std::unique_ptr<llm::TextLLMRunner> lora_runner =
+      llm::create_text_llm_runner(lora_model_path, std::move(tokenizer2),
+                                  foundation_weights_path, temperature);
 
   // Generate.
   llm::GenerationConfig config{.seq_len = seq_len, .temperature = temperature};

--- a/program-data-separation/export_lora.sh
+++ b/program-data-separation/export_lora.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -exu
+
+python -m pip install torchtune==0.7.0.dev20250730  --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+
+# Download model artifacts from HF.
+DOWNLOADED_PATH=$(python -c "
+from huggingface_hub import snapshot_download
+path=snapshot_download(
+    repo_id=\"lucylq/llama3_1B_lora\",
+)
+import os
+print(path)
+")
+
+# Copy over tokenizer, for use at runtime.
+cp "${DOWNLOADED_PATH}/tokenizer.model" .
+
+# Export a non-LoRA model with program-data separated.
+MODEL="llama_3_2_1B"
+python -m executorch.extension.llm.export.export_llm \
+    base.checkpoint="${DOWNLOADED_PATH}/consolidated.00.pth" \
+    base.params="${DOWNLOADED_PATH}/params.json" \
+    base.tokenizer_path="${DOWNLOADED_PATH}/tokenizer.model" \
+    model.use_kv_cache=true \
+    model.use_sdpa_with_kv_cache=true \
+    model.dtype_override="fp32" \
+    backend.xnnpack.enabled=true \
+    backend.xnnpack.extended_ops=true \
+    export.output_name="${MODEL}.pte" \
+    export.foundation_weights_file="${MODEL}.ptd"
+
+# Export a LoRA model, with program and data separated.
+LORA_MODEL="llama_3_2_1B_lora"
+python -m executorch.extension.llm.export.export_llm \
+    base.checkpoint="${DOWNLOADED_PATH}/consolidated.00.pth" \
+    base.params="${DOWNLOADED_PATH}/params.json" \
+    base.adapter_checkpoint="${DOWNLOADED_PATH}/adapter_model.pt" \
+    base.adapter_config="${DOWNLOADED_PATH}/adapter_config.json" \
+    base.tokenizer_path="${DOWNLOADED_PATH}/tokenizer.model" \
+    model.use_kv_cache=true \
+    model.use_sdpa_with_kv_cache=true \
+    model.dtype_override="fp32" \
+    backend.xnnpack.enabled=true \
+    backend.xnnpack.extended_ops=true \
+    export.output_name="${LORA_MODEL}.pte" \
+    export.foundation_weights_file="foundation.ptd"


### PR DESCRIPTION
On top of: https://github.com/meta-pytorch/executorch-examples/pull/51

With xnnpack weight sharing, we do not see double memory when running the second model. 

Generating with llama:
RSS after loading model: 7886.125000 MiB 
RSS after prompt prefill: 7886.125000 MiB 
RSS after finishing text generation: 7886.125000 MiB

Generating with lora:
RSS after loading model: 7933.523438 MiB
RSS after prompt prefill: 7933.523438 MiB 
RSS after finishing text generation: 7933.523438 MiB 

memory increase from llama -> lora:
47.398438 MiB

File sizes:
```
-rw-r--r-- 1 lfq users 4943000480 Aug 11 15:55 foundation.ptd
-rw-r--r-- 1 lfq users 1078636416 Aug 11 15:55 llama_3_2_1B_lora.pte
-rw-r--r-- 1 lfq users 1051324736 Aug 11 15:53 llama_3_2_1B.pte
```
lora - llama pte size difference (essentially the cost of adapter weights + a bit of program): 
~27.3MB

lora details:
https://huggingface.co/lucylq/llama3_1B_lora/blob/main/adapter_config.json
```
{"r": 64, "lora_alpha": 128, "target_modules": ["q_proj", "v_proj", "o_proj"], "peft_type": "LORA", "base_model_name_or_path": "meta-llama/Llama-3.2-1B-Instruct"}
```

Full output
```
(executorch) [lfq@devvm311.ldc0 /data/users/lfq/executorch-examples/program-data-separation/cpp/lora_example (lfq.lora)]$ ./build/bin/executorch_program_data_separation --lora_model_path=../../models/llama_3_2_1B_lora.pte --llama_model_path=../../models/llama_3_2_1B.pte --tokenizer_path=../../tokenizer.model --data_path=../../models/foundation.ptd
I tokenizers:regex.cpp:27] Registering override fallback regex
I 00:00:00.001300 executorch:main.cpp:74] Running program-data separation lora example...
E tokenizers:hf_tokenizer.cpp:60] Error parsing json file: [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: 'I'
I 00:00:00.135350 executorch:llm_runner_helper.cpp:55] Loaded TikToken tokenizer
E tokenizers:hf_tokenizer.cpp:60] Error parsing json file: [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: 'I'
I 00:00:00.257962 executorch:llm_runner_helper.cpp:55] Loaded TikToken tokenizer
I 00:00:00.257989 executorch:llm_runner_helper.cpp:165] Reading metadata from model
I 00:00:00.817946 executorch:llm_runner_helper.cpp:108] Metadata: use_kv_cache = 1
I 00:00:00.817977 executorch:llm_runner_helper.cpp:108] Metadata: get_max_context_len = 128
I 00:00:00.817982 executorch:llm_runner_helper.cpp:108] Metadata: get_max_seq_len = 128
I 00:00:00.817987 executorch:llm_runner_helper.cpp:108] Metadata: use_sdpa_with_kv_cache = 1
I 00:00:00.817991 executorch:llm_runner_helper.cpp:108] Metadata: enable_dynamic_shape = 1
I 00:00:00.817998 executorch:llm_runner_helper.cpp:138] eos_id = 2
I 00:00:00.818008 executorch:llm_runner_helper.cpp:165] Reading metadata from model
I 00:00:01.377309 executorch:llm_runner_helper.cpp:108] Metadata: use_kv_cache = 1
I 00:00:01.377338 executorch:llm_runner_helper.cpp:108] Metadata: get_max_context_len = 128
I 00:00:01.377342 executorch:llm_runner_helper.cpp:108] Metadata: get_max_seq_len = 128
I 00:00:01.377346 executorch:llm_runner_helper.cpp:108] Metadata: use_sdpa_with_kv_cache = 1
I 00:00:01.377348 executorch:llm_runner_helper.cpp:108] Metadata: enable_dynamic_shape = 1
I 00:00:01.377354 executorch:llm_runner_helper.cpp:138] eos_id = 2
I 00:00:01.377364 executorch:main.cpp:112] Generating with llama...
I 00:00:07.774850 executorch:text_llm_runner.cpp:99] RSS after loading model: 7886.125000 MiB (0 if unsupported)
I 00:00:07.775094 executorch:text_llm_runner.cpp:152] Max new tokens resolved: 121, given start_pos 0, num_prompt_tokens 7, max_context_len 128
The answer to the ultimate question isI 00:00:07.907301 executorch:text_prefiller.cpp:92] Prefill token result numel(): 128256
 notI 00:00:07.907502 executorch:text_llm_runner.cpp:183] RSS after prompt prefill: 7886.125000 MiB (0 if unsupported)
 a simple yes or no, but a complex and multifaceted one. The answer is not a single word, but a series of words, a tapestry of thoughts and emotions, a kaleidoscope of experiences. The answer is not a simple yes or no, but a complex and multifaceted one. The answer is not a single word, but a series of words, a tapestry of thoughts and emotions, a kaleidoscope of experiences. The answer is not a simple yes or no, but a complex and multifaceted one. The answer is not a single word, but
I 00:00:21.035475 executorch:text_llm_runner.cpp:203] RSS after finishing text generation: 7886.125000 MiB (0 if unsupported)
PyTorchObserver {"prompt_tokens":7,"generated_tokens":120,"model_load_start_ms":1755731429763,"model_load_end_ms":1755731436161,"inference_start_ms":1755731436161,"inference_end_ms":1755731449421,"prompt_eval_end_ms":1755731436293,"first_token_ms":1755731436293,"aggregate_sampling_time_ms":20,"SCALING_FACTOR_UNITS_PER_SECOND":1000}
I 00:00:21.035566 executorch:stats.h:104]       Prompt Tokens: 7    Generated Tokens: 120
I 00:00:21.035568 executorch:stats.h:110]       Model Load Time:                6.398000 (seconds)
I 00:00:21.035570 executorch:stats.h:117]       Total inference time:           13.260000 (seconds)              Rate:  9.049774 (tokens/second)
I 00:00:21.035572 executorch:stats.h:127]               Prompt evaluation:      0.132000 (seconds)               Rate:  53.030303 (tokens/second)
I 00:00:21.035575 executorch:stats.h:136]               Generated 120 tokens:   13.128000 (seconds)              Rate:  9.140768 (tokens/second)
I 00:00:21.035577 executorch:stats.h:147]       Time to first generated token:  0.132000 (seconds)
I 00:00:21.035584 executorch:stats.h:153]       Sampling time over 127 tokens:  0.020000 (seconds)
I 00:00:23.476181 executorch:text_llm_runner.cpp:99] RSS after loading model: 7933.523438 MiB (0 if unsupported)
I 00:00:23.476418 executorch:text_llm_runner.cpp:152] Max new tokens resolved: 121, given start_pos 0, num_prompt_tokens 7, max_context_len 128
The answer to the ultimate question isI 00:00:23.633265 executorch:text_prefiller.cpp:92] Prefill token result numel(): 128256
 "I 00:00:23.633459 executorch:text_llm_runner.cpp:183] RSS after prompt prefill: 7933.523438 MiB (0 if unsupported)
I don't know." But that's okay. Because, in the end, it's not about knowing the answer; it's about understanding the question itself. And that's a mystery that will always remain unsolved.<|eot_id|><|start_header_id|>assistant<|end_header_id|>

This is a beautiful and thought-provoking passage that explores the nature of knowledge and understanding. Here are some key points that can be taken away from this passage:

1. **The answer is not always clear**: The passage suggests that the answer to the ultimate question may not be something that can be easily found or understood. This is a reflection of the
I 00:00:39.511448 executorch:text_llm_runner.cpp:203] RSS after finishing text generation: 7933.523438 MiB (0 if unsupported)
PyTorchObserver {"prompt_tokens":7,"generated_tokens":120,"model_load_start_ms":1755731449421,"model_load_end_ms":1755731451862,"inference_start_ms":1755731451862,"inference_end_ms":1755731467897,"prompt_eval_end_ms":1755731452019,"first_token_ms":1755731452019,"aggregate_sampling_time_ms":16,"SCALING_FACTOR_UNITS_PER_SECOND":1000}
I 00:00:39.511525 executorch:stats.h:104]       Prompt Tokens: 7    Generated Tokens: 120
I 00:00:39.511528 executorch:stats.h:110]       Model Load Time:                2.441000 (seconds)
I 00:00:39.511530 executorch:stats.h:117]       Total inference time:           16.035000 (seconds)              Rate:  7.483630 (tokens/second)
I 00:00:39.511532 executorch:stats.h:127]               Prompt evaluation:      0.157000 (seconds)               Rate:  44.585987 (tokens/second)
I 00:00:39.511542 executorch:stats.h:136]               Generated 120 tokens:   15.878000 (seconds)              Rate:  7.557627 (tokens/second)
I 00:00:39.511548 executorch:stats.h:147]       Time to first generated token:  0.157000 (seconds)
I 00:00:39.511549 executorch:stats.h:153]       Sampling time over 127 tokens:  0.016000 (seconds)
```