### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/cifar/android/CifarETTrainingDemo/README.md
+++ b/cifar/android/CifarETTrainingDemo/README.md
@@ -44,7 +44,7 @@ $ ./install_executorch.sh
 $ ./scripts/build_android_library.sh
 
 # Fetch the examples
-$ git clone git@github.com:pytorch-labs/executorch-examples.git
+$ git clone git@github.com:meta-pytorch/executorch-examples.git
 
 # Copy the ExecuTorch AAR into the libs directory
 $ mkdir -p executorch-examples/cifar/android/CifarETTrainingDemo/app/libs

--- a/mv3/apple/ExecuTorchDemo/README.md
+++ b/mv3/apple/ExecuTorchDemo/README.md
@@ -61,7 +61,7 @@ Alternatively, clone ExecuTorch and set up the environment as explained in the [
 ### 5. Clone the Demo App
 
 ```bash
-git clone https://github.com/pytorch-labs/executorch-examples.git && cd executorch-examples
+git clone https://github.com/meta-pytorch/executorch-examples.git && cd executorch-examples
 ```
 
 ## Models and Labels
@@ -130,4 +130,4 @@ you can explore and enjoy the power of ExecuTorch on your iOS device!
 
 Learn more about integrating and running [ExecuTorch on Apple](https://pytorch.org/executorch/main/using-executorch-ios.html) platforms.
 
-For specific examples, take a look at this [GitHub repository](https://github.com/pytorch-labs/executorch-examples/mv3/apple/ExecuTorchDemo/).
+For specific examples, take a look at this [GitHub repository](https://github.com/meta-pytorch/executorch-examples/mv3/apple/ExecuTorchDemo/).


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:27:07.535139+00:00Z