### PR TITLE
Add support when QNN backend is used with demo app for dl3

### DIFF
--- a/dl3/android/DeepLabV3Demo/README.md
+++ b/dl3/android/DeepLabV3Demo/README.md
@@ -39,6 +39,8 @@ Run the following adb command to push the model.
 adb push dl3_xnnpack_fp32.pte /data/local/tmp/dl3_xnnpack_fp32.pte
 ```
 
+Note: If you want to use a QNN lowered model, you mush modify the maven executorch dependency to [executorch-qnn](https://mvnrepository.com/artifact/org.pytorch/executorch-android-qnn) and rebuild the app.
+
 ## Step 5: Load and Test Custom Images (No APK Rebuild Needed)
 You can now test image segmentation on your own images (supported formats: .jpg, .jpeg, .png) without rebuilding the APK. The app supports loading .jpg, .jpeg, and .png images from the /sdcard/Pictures/ directory, with user-granted permissions.
 

--- a/dl3/android/DeepLabV3Demo/app/src/main/AndroidManifest.xml
+++ b/dl3/android/DeepLabV3Demo/app/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <uses-native-library
+            android:name="libcdsprpc.so"
+            android:required="false" />
     </application>
 
 </manifest>

--- a/dl3/android/DeepLabV3Demo/app/src/main/java/org/pytorch/executorchexamples/dl3/MainActivity.java
+++ b/dl3/android/DeepLabV3Demo/app/src/main/java/org/pytorch/executorchexamples/dl3/MainActivity.java
@@ -18,6 +18,8 @@ import android.os.Bundle;
 import android.os.Build;
 import android.os.Environment;
 import android.os.SystemClock;
+import android.system.ErrnoException;
+import android.system.Os;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -26,6 +28,7 @@ import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
@@ -178,10 +181,18 @@ public class MainActivity extends Activity implements Runnable {
     }
   }
 
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
+
+    try {
+      Os.setenv("ADSP_LIBRARY_PATH", getApplicationInfo().nativeLibraryDir, true);
+      Os.setenv("LD_LIBRARY_PATH", getApplicationInfo().nativeLibraryDir, true);
+    } catch (ErrnoException e) {
+      finish();
+    }
 
     // Initialize all views first!
     mImageView = findViewById(R.id.imageView);


### PR DESCRIPTION
I was testing if the demo app work with DL3 model lowered to the QNN backend, found out few missing dependencies crashing the app. Without these dependencies it would crash the app with below errors:

```
09-27 03:31:40.850 28552 28862 I [Qnn ExecuTorch]: Deserializing processed data using QnnContextCustomProtocol
09-27 03:31:40.851 28552 28862 I [Qnn ExecuTorch]: create QNN Logger with log_level 1
09-27 03:31:40.852 28552 28862 I [Qnn ExecuTorch]: Initialize Qnn backend parameters for Qnn executorch backend type 2
09-27 03:31:40.854 28552 28862 I [Qnn ExecuTorch]: Caching: Caching is in RESTORE MODE.
09-27 03:31:40.854 28552 28862 I [Qnn ExecuTorch]: QnnContextCustomProtocol expected magic number: 0x5678abcd but get: 0x2000000
09-27 03:31:40.854 28552 28862 E [Qnn ExecuTorch]: QnnDsp <E> Failed to create transport for device, error: 4000
09-27 03:31:40.854 28552 28862 E [Qnn ExecuTorch]: QnnDsp <E> Failed to load skel, error: 4000
09-27 03:31:40.855 28552 28862 E [Qnn ExecuTorch]: QnnDsp <E> Transport layer setup failed: 14001
09-27 03:31:40.855 28552 28862 E [Qnn ExecuTorch]: QnnDsp <E> Failed to parse default platform info: 14001
09-27 03:31:40.855 28552 28862 E [Qnn ExecuTorch]: QnnDsp <E> Failed to load default platform info: 14001
09-27 03:31:40.855 28552 28862 E [Qnn ExecuTorch]: QnnDsp <E> Failed to parse platform config: 14001
09-27 03:31:40.855 28552 28862 E [Qnn ExecuTorch]: Failed to create device_handle for Backend ID 6, error=14001
09-27 03:31:40.855 28552 28862 E ExecuTorch: Fail to configure Qnn device
09-27 03:31:40.855 28552 28862 E ExecuTorch: Fail to initialize Qnn Manager
09-27 03:31:40.855 28552 28862 E ExecuTorch: Init failed for backend QnnBackend: 0x1
```